### PR TITLE
proposed `empty_like()` method for `Scalar`, `Vector` and `Matrix`

### DIFF
--- a/grblas/matrix.py
+++ b/grblas/matrix.py
@@ -325,6 +325,12 @@ class Matrix(BaseType):
         rv._ncols = ncols.scalar.value
         return rv
 
+    def empty_like(self, dtype, *, name=None):
+        """
+        Create a new empty Matrix from the given type and the same shape as this one
+        """
+        return Matrix.new(dtype, nrows=self.nrows, ncols=self.ncols, name=name)
+
     @classmethod
     def from_values(
         cls,

--- a/grblas/scalar.py
+++ b/grblas/scalar.py
@@ -280,6 +280,12 @@ class ScalarExpression(BaseExpression):
     def new(self, dtype=None, *, name=None):
         return super().new(dtype, name=name)
 
+    def empty_like(self, dtype, *, name=None):
+        """
+        Create a new empty Scalar from the given type like this one
+        """
+        return self.new(dtype, name=name)
+
     dup = new
 
     def __repr__(self):

--- a/grblas/vector.py
+++ b/grblas/vector.py
@@ -286,6 +286,12 @@ class Vector(BaseType):
         rv._size = size.scalar.value
         return rv
 
+    def empty_like(self, dtype, *, name=None):
+        """
+        Create a new empty Vector from the given type and the same size as this one
+        """
+        return Vector.new(dtype, size=self.size, name=name)
+
     @classmethod
     def from_values(cls, indices, values, dtype=None, *, size=None, dup_op=None, name=None):
         """Create a new Vector from the given lists of indices and values.  If


### PR DESCRIPTION
Hi @eriknw

Here's a proposal for a small but useful addition to `grblas` which could go a long way to shorten code in `dask-grblas`, specifically the masked `matmul` code:

* add a method `empty_like()` to classes `Scalar`, `Vector`, and `Matrix`.

For example, in the chunk-function `_matmul2_masked` in `dask-grblas`:

```python
def _matmul2_masked(op, dtype, at, bt, mask, a, b, computing_meta=None):
    left = _transpose_if(a, at)
    right = _transpose_if(b, bt)
    mask = mask_type(mask.value)
    C = mask.mask.empty_like(dtype)
    C(mask=mask) << op(left @ right)
    return C
```
the parameter `mask` has a `mask` property that can be either a `Scalar`, `Vector`, or `Matrix`.  So having a method like `empty_like()` avoids having to code separate branches for each type.

Having said that, please feel free to direct me to a better alternative if you have one.